### PR TITLE
Auto-remove too old and unneeded scan tables

### DIFF
--- a/Source/Frame.lua
+++ b/Source/Frame.lua
@@ -10,13 +10,27 @@ function PreserveAuctionatorAHScanDataFrameMixin:ReceiveEvent(eventName, eventDa
   if Auctionator.FullScan and Auctionator.FullScan.Events and eventName == Auctionator.FullScan.Events.ScanComplete then
     PRESERVE_AUCTIONATOR_AH_SCAN_LAST_SCAN = {
       realm = Auctionator.Variables.GetConnectedRealmRoot(),
+      time = time(),
       data = eventData,
     }
+    PRESERVE_AUCTIONATOR_AH_SCAN_LAST_SUMMARY = nil
   elseif Auctionator.IncrementalScan and Auctionator.IncrementalScan.Events and eventName == Auctionator.IncrementalScan.Events.ScanComplete then
     PRESERVE_AUCTIONATOR_AH_SCAN_LAST_SUMMARY = {
       realm = Auctionator.Variables.GetConnectedRealmRoot(),
+      time = time(),
       data = eventData,
     }
+    PRESERVE_AUCTIONATOR_AH_SCAN_LAST_SCAN = nil
+  end
+end
+
+local function removeAgedData()
+  local now, maxAge = time(), 60 * 60
+  for _, v in ipairs({ "PRESERVE_AUCTIONATOR_AH_SCAN_LAST_SCAN", "PRESERVE_AUCTIONATOR_AH_SCAN_LAST_SUMMARY" }) do
+    if _G[v] and _G[v].data and (not _G[v].time or now - _G[v].time > maxAge) then
+      wipe(_G[v])
+      -- print(format("Preserve Auctionator AH Scan: Removed scan data for Collectionator that was over %d minutes old.", maxAge / 60))
+    end
   end
 end
 
@@ -34,4 +48,5 @@ function PreserveAuctionatorAHScanDataFrameMixin:OnEvent(event, ...)
       })
     end
   end
+  removeAgedData()
 end


### PR DESCRIPTION
Initially this PR included the addition of the summary scan, since the version I got from CurseForge was a version before you added that (see issue #1).

I rebased this on your latest GitHub commit and post it nevertheless, since it adds two little things which I find useful:

Due to the potentially large amount of data (especially replicate scan, which gives me a 115MB(!) file):

- When a scan data table is created (either replicate or summary type), an existing one of the other type will be deleted.
- The age of the data is checked at login and the table will be wiped if older than X (currently 60 minutes[^1]). Of course, preventing the display of completely outdated data in Collectionator is another good reason for the timed deletion.

Note: I had a login message in case of data removal (around line 32), but commented it out then, because of the already overwhelming login message spam from so many other addons. YMMV.

[^1]: 60 minutes might seem a bit generous, and carry the risk of people complaining about wrong Collectionator results. But, this addon must be explicitly installed by the user, so they should be aware, and the Scan button is always at our fingertips in Collectionator.